### PR TITLE
Inner Temple Treasurers' Stewards' and Butlers' Accounts file and Temporary endnote file

### DIFF
--- a/IT_ParliamentBook1-2.xml
+++ b/IT_ParliamentBook1-2.xml
@@ -668,7 +668,7 @@
                      M<ex>agist</ex>ri <note type="marginal" place="margin_left">Vnde sol<ex>u</ex>ta
                         xiij s. iiij d.</note>de Revels et de om<ex>n</ex>ib<ex>us</ex> vacacionib<ex>us</ex> certis
                      consideracionib<ex>us</ex> p<ex>ro</ex> ‸<add place="above">fine</add></cell> <!-- KC: caret -->
-                  <cell>xl s.</cell>
+                  <cell rend="right">xl s.</cell>
                </row>
             </table>
             

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -231,10 +231,79 @@
       </profileDesc>
       <revisionDesc>
          <!-- Add new major milestone changes to top -->
+         <change when="2018-05-14" who="#KC">added records to file</change>
          <change when="2018-02-03" who="#JAKA1">created document</change>
       </revisionDesc>
    </teiHeader>
-
+   
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1605-09-29" to-iso="1606-09-29" cert="medium">1605-6</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 137-8">RLITTS</seg></head>
+         <div type="transcription">
+            <div>
+               <head>f 2 <date from-iso="1605-11-01" to-iso="1606-11-01"></date><supplied>( 1 November - 1 November) (All Payments)</supplied></head>
+               <pb n="2" type="folio"/> 
+         
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d for a play on Allhollanday Anno D<ex>omi</ex>ni 1605</cell>
+                     <cell>v li.</cell>
+                  </row>
+                  <gap reason="omitted"/>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to the Musytyons the same daye</cell>
+                     <cell>xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 2v</head>
+               <pb n="2v" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d for iiij<hi rend="superscript">or</hi> staftorches for Revell<ex>es</ex> the Satterdaye
+                        before Candlemas daye<note type="foot">Satterdaye
+                           before Candlemas daye: <hi rend="italic">26 January 1605/6</hi></note></cell>
+                     <cell>iiij s.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d for a Play on Candlemas day
+                        laste 1605</cell>
+                     <cell>v li.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 3</head>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to the Musyc<ex>i</ex>ons the same daye</cell>
+                     <cell>xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+         </div>
+      </body>
+   </text>
+   
+   
+   
+   
+   
+   
+   
+<!-- =============================================== -->   
+<!-- KC: record added by Diane Jakacki -->
    <text ana="taxon:inner_temple" type="record">
       <body xml:lang="eng">
          <head>

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -1200,7 +1200,7 @@
    <text ana="taxon:inner_temple" type="record">
       <body xml:lang="eng">
          <head>
-            <date from-iso="1618-09-29" to-iso="1619-09-29" cert="medium">1618-9</date>
+            <date from-iso="1618-09-29" to-iso="1619-09-29" cert="medium">1618-19</date>
             <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 203">RLITTS</seg></head>
          
          <div type="transcription">
@@ -1249,6 +1249,51 @@
       </body>
    </text>
                
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1619-09-29" to-iso="1620-09-29" cert="medium">1619-20</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 205">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 141 <date from-iso="1619-11-01" to-iso="1620-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <pb n="141" type="folio"/> 
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item paid for a play on Allhollonday 1619</cell>
+                     <cell rend="right">7</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+                  <row>
+                     <cell>Item for a play on Candlemas day last 1619.</cell>
+                     <cell rend="right">7</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item paid to the Musitians for there whole yeares fee</cell>
+                     <cell rend="right">2</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+                  <row>
+                     <cell>Item to them more for the fift of Nouember</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">13</cell>
+                     <cell rend="right">4</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+         </div>
+      </body>
+   </text>
    
    
    

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -251,12 +251,12 @@
                <table>
                   <row>
                      <cell>It<ex>e</ex>m p<ex>ai</ex>d for a play on Allhollanday Anno D<ex>omi</ex>ni 1605</cell>
-                     <cell>v li.</cell>
+                     <cell rend="right">v li.</cell>
                   </row>
                   <gap reason="omitted"/>
                   <row>
                      <cell>It<ex>e</ex>m p<ex>ai</ex>d to the Musytyons the same daye</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -271,12 +271,12 @@
                      <cell>It<ex>e</ex>m p<ex>ai</ex>d for iiij<hi rend="superscript">or</hi> staftorches for Revell<ex>es</ex> the Satterdaye
                         before Candlemas daye<note type="foot">Satterdaye
                            before Candlemas daye: <hi rend="italic">26 January 1605/6</hi></note></cell>
-                     <cell>iiij s.</cell>
+                     <cell rend="right">iiij s.</cell>
                   </row>
                   <row>
                      <cell>It<ex>e</ex>m p<ex>ai</ex>d for a Play on Candlemas day
                         laste 1605</cell>
-                     <cell>v li.</cell>
+                     <cell rend="right">v li.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -287,7 +287,7 @@
                <table>
                   <row>
                      <cell>It<ex>e</ex>m p<ex>ai</ex>d to the Musyc<ex>i</ex>ons the same daye</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -314,7 +314,7 @@
                   <row>
                      <cell>Item paid to the Music<ex>i</ex>ons for their fee on
                         Alhollandaie 1606</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -329,23 +329,23 @@
                      <cell>I
                         tem paid for 2 staffetorches for the revells on
                         Candlemas Even</cell>
-                     <cell>ij s.</cell>
+                     <cell rend="right">ij s.</cell>
                   </row>
                   <row>
                      <cell>Item paid for a play on Candlemas Daye 1606</cell>
-                     <cell>v li.</cell>
+                     <cell rend="right">v li.</cell>
                   </row>
                   <gap reason="omitted"/>
                   <row>
                      <cell>Item paid to the Music<ex>i</ex>ons for their ffee the
                         same daie</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                   <gap reason="omitted"/>
                   <row>
                      <cell>Item paid for 4 staff torches for the Revells the
                         same daie</cell>
-                     <cell>iiij s.</cell>
+                     <cell rend="right">iiij s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -360,7 +360,7 @@
                      <cell>Item paid to Raphe Smyth the Carpenter <gap reason="omitted"/> for pullinge
                         downe the gallery in the hall where the Musicons<note type="foot">Musicons: <hi rend="italic">for</hi> Music<ex>i</ex>ons<hi rend="italic">abbreviation mark missing</hi></note> vse
                         to staund</cell>
-                     <cell>ij s. vj d.</cell>
+                     <cell rend="right">ij s. vj d.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -391,7 +391,7 @@
                <table>
                   <row>
                      <cell>Item paid for the Musitions fee the same day<note type="foot">the same day: <hi rend="italic">All Hallows' Day</hi></note></cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -405,24 +405,24 @@
                      <row>
                         <cell>Item paid for 2 staffe torches for the revells on
                            Candlemas Even</cell>
-                        <cell>ij s.</cell>
+                        <cell rend="right">ij s.</cell>
                      </row>
                       <row>
                          <cell>Item paid for a play on Candlemas Day called
                             Oxford Tragedye</cell>
-                         <cell>v li.</cell>
+                         <cell rend="right">v li.</cell>
                       </row>
                   </table>
                    <gap reason="omitted"/>
                   <table>
                      <row>
                         <cell>Item paid for 2 staffe torches the same daye</cell>
-                        <cell>ij s.</cell>
+                        <cell rend="right">ij s.</cell>
                      </row>
                      <row>
                         <cell>Item paid to the Music<ex>i</ex>ons for their ffee the
                            same Daye</cell>
-                        <cell>xx s.</cell>
+                        <cell rend="right">xx s.</cell>
                      </row>
                   </table>
                   <gap reason="omitted"/>
@@ -451,7 +451,7 @@
                   <row>
                      <cell>Ite<ex>m</ex> paid for a play on Allhollen Daie anno
                         d<ex>omi</ex>ni 1608</cell>
-                     <cell>iiij li. xv s.</cell>
+                     <cell rend="right">iiij li. xv s.</cell>
                   </row>
                </table>
             </div>
@@ -463,12 +463,12 @@
                <table>
                   <row>
                      <cell>Ite<ex>m</ex> paid to the music<ex>i</ex>ons the same daie</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                   <row>
                      <cell>Ite<ex>m</ex> paid for 3 do<ex>ssen</ex> 3 torches spent this whole
                         yeare at Revells at x s. the dozen</cell>
-                     <cell>xxxij s. vj d.</cell>
+                     <cell rend="right">xxxij s. vj d.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -483,12 +483,12 @@
                   <row>
                      <cell>Ite<ex>m</ex> given to the gent<ex>lemens</ex> Revelles in Mich<ex>aelm</ex>as
                         Terme 3 revelling night<ex>es</ex></cell>
-                     <cell>iij li.</cell>
+                     <cell rend="right">iij li.</cell>
                   </row>
                      <gap reason="omitted"/>
                   <row>
                      <cell>Ite<ex>m</ex> paied for a play on Candlemas Daie laste 1608</cell>
-                     <cell>v li.</cell>
+                     <cell rend="right">v li.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -507,12 +507,12 @@
             
             <div>
                <head>f 47v <date from-iso="1609-11-01" to-iso="1610-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
-               <pb n="36" type="folio"/> 
+               <pb n="47v" type="folio"/> 
                <gap reason="omitted"/>    
                <table>
                   <row>
                      <cell>It<ex>em</ex> paid for a play on Alholand day 1609</cell>
-                     <cell>v li.</cell>
+                     <cell rend="right">v li.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -524,18 +524,18 @@
                <table>
                   <row>
                      <cell>Item paid for musicke the same day</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
                <table>
                   <row>
                      <cell>It<ex>em</ex> paid for a play on Candlemas day</cell>
-                     <cell>v li.</cell>
+                     <cell rend="right">v li.</cell>
                   </row>
                   <row>
                      <cell>It<ex>em</ex> paid for musicke the same day</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -562,11 +562,11 @@
                   <row>
                      <cell>Item paid for a play on Alhallonday Anno
                D<ex>omi</ex>ni 1610</cell> 
-                     <cell>vj li.</cell>
+                     <cell rend="right">vj li.</cell>
                   </row>
                   <row>
                      <cell>It<ex>em</ex> paid for Musick the same day</cell> 
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                
@@ -574,11 +574,11 @@
                <table>
                   <row>
                      <cell>Item paid for Musicke the 5 No<ex>vember</ex> 1610</cell> 
-                     <cell>xiij s. iiij d.</cell>
+                     <cell rend="right">xiij s. iiij d.</cell>
                   </row>
                <row>
                   <cell>Item paid for two staffe torches the same day</cell> 
-                  <cell>ij s.</cell>
+                  <cell rend="right">ij s.</cell>
                </row>
                </table>
                
@@ -586,11 +586,11 @@
                <table>
                   <row>
                      <cell>Item paid for a play on Candlemas day last</cell>
-                     <cell> v li.</cell>
+                     <cell rend="right">v li.</cell>
                   </row>
                   <row>
                      <cell>It<ex>em</ex> paid for musicke the same day</cell>
-                     <cell> xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -598,7 +598,7 @@
                <table>
                   <row>
                      <cell> It<ex>em</ex> paid for 2 staffe torches the same day</cell>
-                     <cell>ij s.</cell>
+                     <cell rend="right">ij s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -618,47 +618,47 @@
          <div type="transcription">
             
             <div>
-               <head>f 64-4v <date from-iso="1611-11-01" to-iso="1612-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <head>f 64-4v <date from-iso="1611-11-01" to-iso="1612-11-01"></date><supplied>( 1 November - 1 November) (Payments)</supplied></head>
                <pb n="64-4v" type="folio"/> 
                <gap reason="omitted"/>       
                <table>
                   <row>
                      <cell>Item paid for 2 staffe torches vppon Alhollowday</cell>
-                     <cell>ij s.</cell>
+                     <cell rend="right">ij s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
                <table>
                   <row>
                      <cell>It<ex>em</ex> paid to the Musicions for their ffee the same day</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                   <row>
                      <cell>It<ex>em</ex> paid for a Consort of Musicke the same day</cell>
-                     <cell>l s.</cell>
+                     <cell rend="right">l s.</cell>
                   </row>
                   <row>
                      <cell>It<ex>em</ex> for Antick<ex>es</ex> or puppitt<ex>es</ex> the same day</cell>
-                     <cell>xl s.</cell>
+                     <cell rend="right">xl s.</cell>
                   </row>
                   <row>
                      <cell>It<ex>em</ex> paid for the Music<ex>i</ex>ons ffee the 5 of N<ex>ovember</ex></cell>
-                     <cell>xiij s. iiij d.</cell>
+                     <cell rend="right">xiij s. iiij d.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
                <table>
                   <row>
                      <cell>Item paid for 2 staffe torches on Candlemas day</cell>
-                     <cell>ij s. |</cell>
+                     <cell rend="right">ij s. |</cell>
                   </row>
                   <row>
                      <cell>Item paid for a play the same day</cell>
-                     <cell>vj li.</cell>
+                     <cell rend="right">vj li.</cell>
                   </row>
                   <row>
                      <cell>Item paid for Musicke the same day</cell>
-                     <cell>xx s.</cell>
+                     <cell rend="right">xx s.</cell>
                   </row>
                </table>
                <gap reason="omitted"/>
@@ -672,67 +672,56 @@
       </body>
    </text>
                
-               
-               
-               
-               
-               
-               
-
-
-
-
-<!-- =============================================== -->   
-<!-- KC: record added by Diane Jakacki -->
+<!-- KC: record added by Diane Jakacki, revised by KC-->
    <text ana="taxon:inner_temple" type="record">
       <body xml:lang="eng">
          <head>
-            <date from-iso="1612" to-iso="1613">1612-1613</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RLPIC1 pp. 153, 176">RLITTS</seg></head>
+            <date from-iso="1612-09-29" to-iso="1613-09-29">1612-1613</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RLPIC1 pp. 153">RLITTS</seg></head>
          <div type="transcription">
             <div>
-            <head>f 72v <supplied>(1 November - 1 November) (Payments)</supplied></head>
-            <pb n="f 72v" type="folio"/>
+               <head>f 72v <date from-iso="1612-11-01" to-iso="1613-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+            <pb n="72v" type="folio"/>
             <gap reason="omitted"/>
             <table>
                <row>
                   <cell>Item payd for 2 staffe torches on Alhallonday</cell>
-                  <cell>ij s.</cell>
+                  <cell rend="right">ij s.</cell>
                </row>
                <gap reason="omitted"/>
                <row>
                   <cell>Item payd to Musitians for theyr ffee the same day</cell>
-                  <cell>xx s.</cell>
+                  <cell rend="right">xx s.</cell>
                </row>
                <row>
                   <cell>Item payd for a playe the same day</cell>
-                  <cell>v li.</cell>
+                  <cell rend="right">v li.</cell>
                </row>
                <gap reason="omitted"/>
                <row>
                   <cell>Item payd to the Musitions for their ffee the v<hi rend="superscript">th</hi> of November</cell>
-                  <cell>xiij s. iiij d.</cell>
+                  <cell rend="right">xiij s. iiij d.</cell>
                </row>
                <row>
                   <cell>Item payd for a play on Candlemas day</cell>
-                  <cell>vj li. xiij s. iiij d.</cell>                  
+                  <cell rend="right">vj li. xiij s. iiij d.</cell>                  
                </row>
                <row>
                   <cell>Item payd to another company of players w<ex>hi</ex>ch were appointed to play heere the same day</cell>
-                  <cell>xxx s.</cell>
+                  <cell rend="right">xxx s.</cell>
                </row>
                <row>
                   <cell>Item p<ex>ay</ex>d for 2 staffe torches the same day</cell>
-                  <cell>ij s.</cell>
+                  <cell rend="right">ij s.</cell>
                </row>
                <gap reason="omitted"/>
                <row>
                   <cell>Item p<ex>ay</ex>d for ye Musitians fee the same day</cell>
-                  <cell>xx s.</cell>
+                  <cell rend="right">xx s.</cell>
                </row>
                <row>
                   <cell>Item payd for one dosen of torches for the Revells in Mich<ex>aelm</ex>as terme 1612</cell>
-                  <cell>x s.</cell>
+                  <cell rend="right">x s.</cell>
                </row>               
             </table>
        
@@ -743,16 +732,16 @@
             
          <div>
             <head>f 73 <supplied></supplied></head>
-            <pb n="f 73" type="folio"/>
+            <pb n="73" type="folio"/>
             <gap reason="omitted"/>
             <table>
                <row>
                   <cell>It<ex>em</ex> payd for 6 torches for the benchers to see the maske at Elye house</cell>
-                  <cell>v s.</cell>
+                  <cell rend="right">v s.</cell>
                </row>
                <row>
                   <cell>It<ex>em</ex> payd for 2 torches another tyme to goe to Item payd for 2 torches another tyme to goe to</cell>
-                  <cell>ij s.</cell>
+                  <cell rend="right">ij s.</cell>
                </row>
             </table>
             <gap reason="omitted"/>
@@ -763,16 +752,16 @@
             
          <div>
             <head>f 75v <supplied></supplied></head>
-            <pb n="f 75v" type="folio"/>
+            <pb n="75v" type="folio"/>
             <gap reason="omitted"/>
             <table>
                <row>
                   <cell>Item paid to Mr Lewes Hele at 2 seu<ex>er</ex>all tymes toward<ex>es</ex> the maske busines</cell>
-                  <cell>lxx li.</cell>
+                  <cell rend="right">lxx li.</cell>
                </row>
                <row>
                   <cell>Item paid to Mr ffenner towarde the same busines</cell>
-                  <cell>x li.</cell>
+                  <cell rend="right">x li.</cell>
                </row>
                <row>
                   <cell>Item paid to a messinger w<ex>hi</ex>ch Mr ffenner p<ex>ro</ex>vided ‸<add place="above">to fetch Mr Beamont</add></cell>
@@ -780,49 +769,59 @@
                <gap reason="omitted"/>
                <row>
                   <cell>Item paid to Iohn Hodgkins for boate hyer to and fro to Winchester howse about the maske busines</cell>
-                  <cell>ij s. vj d.</cell>
+                  <cell rend="right">ij s. vj d.</cell>
                </row>
             </table>
             <note type="editorial" n="endnote">            
-               Winchester House (p 153, l.39) was the residence of the bishop of Winchester in Southwark. It was from Southwark that the Inner Temple and Gray's Inn masquers proceeded by water to Whitehall, the theme of the masque being the marriage of the Rivers Thames and Rhine.
+               Winchester House (p 153, l.39) was the residence of the bishop of Winchester in Southwark. It was from Southwark that the Inner Temple and Gray's Inn masquers proceeded by water to Whitehall, the theme of the masque being the marriage of the Rivers Thames and Rhine.  <!-- KC: Cross-reference -->
             </note>
          </div>
+         </div>
+      </body>
+   </text>
+   
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1613-09-29" to-iso="1614-09-29" cert="medium">1613-14</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 176">RLITTS</seg></head>
          
+         <div type="transcription">
          <div>
-            <head>f 82 <supplied>(1 November - 1 November) (Payments)</supplied></head>
-            <pb n="f 82" type="folio"/>
+            <head>f 82 <date from-iso="1613-11-01" to-iso="1614-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+            <pb n="82" type="folio"/>
             <gap reason="omitted"/>
             <table>
                <row>
                   <cell>It<ex>e</ex>m paid for a play vpon all saint<ex>es</ex> day 1613</cell>
-                  <cell>vj li. xiij s. iiij d.</cell>
+                  <cell rend="right">vj li. xiij s. iiij d.</cell>
                </row>
                <row>
                   <cell>It<ex>e</ex>m p<ex>ai</ex>d for 2 staffe torches ye same day</cell>
-                  <cell>ij s.</cell>
+                  <cell rend="right">ij s.</cell>
                </row>
                <gap reason="omitted"/>
                <row>
                   <cell>It<ex>e</ex>m p<ex>ai</ex>d for the Music<ex>io</ex>ns ffee ye same day</cell>
-                  <cell>xx s.</cell>
+                  <cell rend="right">xx s.</cell>
                </row>
                <row>
                   <cell>It<ex>e</ex>m p<ex>ai</ex>d for theyr ffee on the fifte of Novemb<ex>er</ex></cell>
-                  <cell>xiij s. iiij d.</cell>
+                  <cell rend="right">xiij s. iiij d.</cell>
                </row>
                <gap reason="omitted"/>
                <row>
                   <cell>It<ex>e</ex>m p<ex>ai</ex>d for a play one Candlemas day 1613</cell>
-                  <cell>vj li. xiij s. iiij d.</cell>
+                  <cell rend="right">vj li. xiij s. iiij d.</cell>
                </row>
                <row>
                   <cell>It<ex>e</ex>m for 2 staffe torches the same day</cell>
-                  <cell>ij s.</cell>
+                  <cell rend="right">ij s.</cell>
                </row>
                <gap reason="omitted"/>
                <row>
                   <cell>It<ex>e</ex>m p<ex>ai</ex>d for the Musitions ffee the same day</cell>
-                  <cell>xx s.</cell>
+                  <cell rend="right">xx s.</cell>
                </row>
                <gap reason="omitted"/>
             </table>
@@ -830,5 +829,101 @@
          </div>
       </body>
    </text>
+  
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1614-09-29" to-iso="1615-09-29" cert="medium">1614-15</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 182">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 91v <date from-iso="1614-11-01" to-iso="1615-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <pb n="91v" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+               <row>
+                  <cell>Item p<ex>ay</ex>d to the Kinges Ma<ex>ies</ex>ties servant<ex>es</ex> for a
+                     play vpon allsaint<ex>es</ex> day 1614</cell>
+                  <cell rend="right">vj li.</cell>
+               </row>
+               </table>
+               <gap reason="omitted"/>
+               <note type="editorial" n="endnote">
+                  The phrase 'the Kinges Maiesties servantes' (l.18, see also l.28) is the earliest indication of which playing company performed at the Inner Temple. Under one name or another (including the 'Blackfryers
+                  Players' in 1629–30: see p 226, l.40) this company – Shakespeare's company – performed at the Inner
+                  Temple from this year forward, and perhaps earlier. But in 1601–2 the same company evidently played
+                  at the Middle Temple: see Appendix 6.3, <title>Twelfth Night</title>.
+               </note>  <!-- KC: cross-referene; also need to revise (can delete? check with Alan) references to "(l.18, see also l.28)" -->
+            </div>
+            
+            <div>
+               <head>f 92</head>
+                  <pb n="92" type="folio"/>
+                  <table>
+                     <row>
+                        <cell>Item p<ex>ay</ex>d for 2 staffe torches the same daye</cell>
+                        <cell rend="right">ij s.</cell>
+                     </row>
+                     <row>
+                        <cell>Item payd to Iohn Hopp<ex>er</ex> for the Musitions fee
+                           the same day</cell>
+                        <cell rend="right">xx s.</cell>
+                     </row>
+                  </table>
+                  <gap reason="omitted"/>
+                  <table>
+                     <row>
+                        <cell>I
+                           tem p<ex>ay</ex>d to his ma<ex>ies</ex>t<ex>ies</ex> s<ex>er</ex>vant<ex>es</ex> for a play vpon Candlemas 
+                           daye last past</cell>
+                        <cell rend="right">vj li. xiij s. iiij d.</cell>
+                     </row>
+                     <row>
+                        <cell>Item p<ex>ay</ex>d for 2 staffe torches the same day</cell>
+                        <cell rend="right">ij s.</cell>
+                     </row>
+                     <row>
+                        <cell>It<ex>em</ex> p<ex>ay</ex>d for ye musitions fee ye same day</cell>
+                        <cell rend="right">xx s.</cell>
+                     </row>
+                  </table>
+                  <gap reason="omitted"/>
+               <note type="editorial" n="endnote">
+                  The phrase 'the Kinges Maiesties servantes' (l.18, see also l.28) is the earliest indication of which playing company performed at the Inner Temple. Under one name or another (including the 'Blackfryers
+                  Players' in 1629–30: see p 226, l.40) this company – Shakespeare's company – performed at the Inner
+                  Temple from this year forward, and perhaps earlier. But in 1601–2 the same company evidently played
+                  at the Middle Temple: see Appendix 6.3, <title>Twelfth Night</title>.
+               </note>   <!-- KC: cross-referene; also need to revise (can delete? check with Alan) references to "(l.18, see also l.28)" -->
+               </div>
+               
+               <div>
+                  <head>f 94v</head>
+                  <pb n="94v" type="folio"/>
+                  <gap reason="omitted"/>
+                  <table>
+                     <row>
+                        <cell>Item p<ex>ay</ex>d to the gent<ex>lemen</ex> reuellars vpon Candlemas
+                           day at night</cell>
+                        <cell rend="right">xl s.</cell>
+                     </row>
+                  </table>
+                  <gap reason="omitted"/>
+                  <note type="editorial" n="endnote">
+                     It is not clear exactly what was being reimbursed or rewarded by the payment on f 94v. The round
+                     sum would suggest a reward rather than a reimbursement. The spending of domus money suggests                         that the student revellers performed before an invited audience whom the Inn wished to impress.                           (See Bulstrode Whitelocke’s description of organizing the revels at Middle Temple 1628–9, pp 223–6.)
+                  </note>  <!-- KC: cross-reference pagination -->
+               </div>
+         </div>
+      </body>
+   </text>
+  
+  
+  
+  
+  
+  
+  
+  
   
 </TEI>

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -911,15 +911,114 @@
                   <gap reason="omitted"/>
                   <note type="editorial" n="endnote">
                      It is not clear exactly what was being reimbursed or rewarded by the payment on f 94v. The round
-                     sum would suggest a reward rather than a reimbursement. The spending of domus money suggests                         that the student revellers performed before an invited audience whom the Inn wished to impress.                           (See Bulstrode Whitelocke’s description of organizing the revels at Middle Temple 1628–9, pp 223–6.)
+                     sum would suggest a reward rather than a reimbursement. The spending of domus money suggests                         that the student revellers performed before an invited audience whom the Inn wished to impress.                           (See Bulstrode Whitelocke’s description of organizing the revels at Middle Temple 1628-9, pp 223-6.)
                   </note>  <!-- KC: cross-reference pagination -->
                </div>
          </div>
       </body>
    </text>
   
-  
-  
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1615-09-29" to-iso="1616-09-29" cert="medium">1615-16</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 186-7">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 103v <date from-iso="1615-11-01" to-iso="1616-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <pb n="103v" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item p<ex>ay</ex>d to the Kinges Ma<ex>ies</ex>tie servant<ex>es</ex> for a play
+                        vpon Allhallon day 1615</cell>
+                     <cell rend="right">v li.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item p<ex>ay</ex>d for 2 staffe torches the same day</cell>
+                     <cell rend="right">ij s.</cell>
+                  </row>
+                  <row>
+                     <cell>Item p<ex>ay</ex>d to Iohn Hopper for ye Musitions fee ye
+                        same day</cell>
+                     <cell rend="right">xx s.</cell>
+                  </row>
+                  <row>
+                     <cell>Item p<ex>ay</ex>d for the Musitions fee the 5<hi rend="superscript">th</hi> of November</cell>
+                     <cell rend="right">xiij s. iiij d.</cell>
+                  </row>
+                  <row>
+                     <cell>Item p<ex>ay</ex>d for 2 dosen of torches for reuells the 5 12
+                        18 &amp; 25 of November<note type="foot">5 12 18 &amp; 25 of November: <hi rend="italic">the first two were Tuesday nights, the second two Monday nights</hi></note></cell>
+                     <cell rend="right">xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 104</head>
+               <pb n="104" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item p<ex>ay</ex>d for a play vpon Candlemas day</cell>
+                     <cell rend="right">vj li. xiij s. iiij d.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item p<ex>ay</ex>d for the musitions fee the same day</cell>
+                     <cell rend="right">xx s.</cell>
+                  </row>
+                  <row>
+                     <cell>Item p<ex>ay</ex>d to<note type="foot">to: <hi rend="italic">for</hi> for</note> 2 staffe torches the same day</cell>
+                     <cell rend="right">ij s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               
+               <div>
+                  <head>f 106v</head>
+                  <pb n="106v" type="folio"/>
+                  <gap reason="omitted"/>
+                  <table>
+                     <row>
+                        <cell>Item p<ex>ay</ex>d to Nicholas Polhill for a debt rem<ex>aining</ex>
+                           due vnto him from this house aboute ye maske
+                           to court</cell>
+                        <cell rend="right">xx li.</cell>
+                     </row>
+                  </table>
+                  <note type="editorial" n="endnote">
+                     <!-- @en 186-7 -->
+                  </note>  <!-- KC: cross-reference -->
+               </div>
+               
+               <div>
+                  <head>f 108</head>
+                  <pb n="108" type="folio"/>
+                  <gap reason="omitted"/>
+                  <table>
+                     <row>
+                        <cell>Item p<ex>ay</ex>d to mr Iordan of the bench towarde the
+                           charge of the barryers</cell>
+                        <cell rend="right">L li.</cell>
+                     </row>
+                  </table>
+                  <gap reason="omitted"/>
+                  <note type="editorial" n="endnote">
+                     <!-- @en 186-7 -->
+                  </note>  <!-- KC: cross-reference -->
+               </div>
+               
+            </div>
+               
   
   
   

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -241,10 +241,12 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1605-09-29" to-iso="1606-09-29" cert="medium">1605-6</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 137-8">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 137-8">RLITTS</seg>
+         </head>
          <div type="transcription">
             <div>
-               <head>f 2 <date from-iso="1605-11-01" to-iso="1606-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head> <!-- KC: we don't supply year dates in the 1 Nov to 1 Nov line unless it is ambiguious, e.g. 1 Nov 1605 to 2 Nov 1606 -->
+               <head>f 2 <date from-iso="1605-11-01" to-iso="1606-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied>
+               </head> <!-- KC: we don't supply year dates in the 1 Nov to 1 Nov line unless it is ambiguious, e.g. 1 Nov 1605 to 2 Nov 1606 -->
                <pb n="2" type="folio"/> 
          
                <gap reason="omitted"/>
@@ -302,10 +304,12 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1606-09-29" to-iso="1607-09-29" cert="medium">1606-7</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 139">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 139">RLITTS</seg>
+         </head>
          <div type="transcription">
             <div>
-               <head>f 12v <date from-iso="1606-11-01" to-iso="1607-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <head>f 12v <date from-iso="1606-11-01" to-iso="1607-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied>
+               </head>
                <pb n="12v" type="folio"/> 
                
                <gap reason="omitted"/>   
@@ -382,11 +386,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1607-09-29" to-iso="1608-09-29" cert="medium">1607-8</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 141">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 141">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 23 <date from-iso="1607-11-01" to-iso="1608-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <head>f 23 <date from-iso="1607-11-01" to-iso="1608-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied>
+               </head>
                <pb n="23" type="folio"/> 
                <gap reason="omitted"/>   
                <table>
@@ -441,12 +447,14 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1608-09-29" to-iso="1609-09-29" cert="medium">1608-9</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 142">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 142">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             
             <div>
-               <head>f 36 <date from-iso="1608-11-01" to-iso="1609-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <head>f 36 <date from-iso="1608-11-01" to-iso="1609-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied>
+               </head>
                <pb n="36" type="folio"/> 
                <gap reason="omitted"/>    
                <table>
@@ -503,12 +511,14 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1609-09-29" to-iso="1610-09-29" cert="medium">1609-10</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 144">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 144">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             
             <div>
-               <head>f 47v <date from-iso="1609-11-01" to-iso="1610-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <head>f 47v <date from-iso="1609-11-01" to-iso="1610-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied>
+               </head>
                <pb n="47v" type="folio"/> 
                <gap reason="omitted"/>    
                <table>
@@ -551,12 +561,14 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1610-09-29" to-iso="1611-09-29" cert="medium">1610-11</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 146">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 146">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             
             <div>
-               <head>f 55v <date from-iso="1610-11-01" to-iso="1611-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <head>f 55v <date from-iso="1610-11-01" to-iso="1611-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied>
+               </head>
                <pb n="55v" type="folio"/> 
                <gap reason="omitted"/>      
                
@@ -615,12 +627,14 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1611-09-29" to-iso="1612-09-29" cert="medium">1611-12</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 147">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 147">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             
             <div>
-               <head>f 64-4v <date from-iso="1611-11-01" to-iso="1612-11-01"></date><supplied>( 1 November - 1 November) (Payments)</supplied></head>
+               <head>f 64-4v <date from-iso="1611-11-01" to-iso="1612-11-01"></date><supplied>( 1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="64-4v" type="folio"/> 
                <gap reason="omitted"/>       
                <table>
@@ -680,10 +694,12 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1612-09-29" to-iso="1613-09-29">1612-1613</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RLPIC1 pp. 153">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RLPIC1 pp. 153">RLITTS</seg>
+         </head>
          <div type="transcription">
             <div>
-               <head>f 72v <date from-iso="1612-11-01" to-iso="1613-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 72v <date from-iso="1612-11-01" to-iso="1613-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
             <pb n="72v" type="folio"/>
             <gap reason="omitted"/>
             <table>
@@ -735,7 +751,7 @@
          </div>
             
          <div>
-            <head>f 73 <supplied></supplied></head>
+            <head>f 73 </head>
             <pb n="73" type="folio"/>
             <gap reason="omitted"/>
             <table>
@@ -756,7 +772,7 @@
          </div>
             
          <div>
-            <head>f 75v <supplied></supplied></head>
+            <head>f 75v </head>
             <pb n="75v" type="folio"/>
             <gap reason="omitted"/>
             <table>
@@ -790,11 +806,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1613-09-29" to-iso="1614-09-29" cert="medium">1613-14</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 176">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 176">RLITTS</seg>
+         </head>
          
          <div type="transcription">
          <div>
-            <head>f 82 <date from-iso="1613-11-01" to-iso="1614-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+            <head>f 82 <date from-iso="1613-11-01" to-iso="1614-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+            </head>
             <pb n="82" type="folio"/>
             <gap reason="omitted"/>
             <table>
@@ -840,11 +858,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1614-09-29" to-iso="1615-09-29" cert="medium">1614-15</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 182">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 182">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 91v <date from-iso="1614-11-01" to-iso="1615-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 91v <date from-iso="1614-11-01" to-iso="1615-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="91v" type="folio"/>
                <gap reason="omitted"/>
                <table>
@@ -933,11 +953,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1615-09-29" to-iso="1616-09-29" cert="medium">1615-16</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 186-7">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 186-7">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 103v <date from-iso="1615-11-01" to-iso="1616-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 103v <date from-iso="1615-11-01" to-iso="1616-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="103v" type="folio"/>
                <gap reason="omitted"/>
                <table>
@@ -1036,11 +1058,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1616-09-29" to-iso="1617-09-29" cert="medium">1616-17</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 191-2">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 191-2">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 114 <date from-iso="1616-11-01" to-iso="1617-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 114 <date from-iso="1616-11-01" to-iso="1617-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="114" type="folio"/>
                <gap reason="omitted"/>  
                <table>
@@ -1150,11 +1174,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1617-09-29" to-iso="1618-09-29" cert="medium">1617-18</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 201-2">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 201-2">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 126v <date from-iso="1617-11-01" to-iso="1618-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 126v <date from-iso="1617-11-01" to-iso="1618-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="126v" type="folio"/>   
                <gap reason="omitted"/>
                <table>
@@ -1201,11 +1227,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1618-09-29" to-iso="1619-09-29" cert="medium">1618-19</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 203">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 203">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 134v <date from-iso="1618-11-01" to-iso="1619-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 134v <date from-iso="1618-11-01" to-iso="1619-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="134v" type="folio"/>   
                <gap reason="omitted"/>
                <table>
@@ -1253,11 +1281,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1619-09-29" to-iso="1620-09-29" cert="medium">1619-20</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 205">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 205">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 141 <date from-iso="1619-11-01" to-iso="1620-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 141 <date from-iso="1619-11-01" to-iso="1620-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="141" type="folio"/> 
                <gap reason="omitted"/>
                <table>
@@ -1299,11 +1329,13 @@
       <body xml:lang="eng">
          <head>
             <date from-iso="1620-09-29" to-iso="1621-09-29" cert="medium">1620-21</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 206-7">RLITTS</seg></head>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 206-7">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 146v <date from-iso="1620-11-01" to-iso="1621-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 146v <date from-iso="1620-11-01" to-iso="1621-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="146v" type="folio"/> 
                <gap reason="omitted"/>
                <table>
@@ -1347,12 +1379,14 @@
    <text ana="taxon:inner_temple" type="record">
       <body xml:lang="eng">
          <head>
-            <date from-iso="1621-09-29" to-iso="1622-09-29" cert="medium">1621-22</date>
-            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 209">RLITTS</seg></head>
+            <date from-iso="1621-09-29" to-iso="1622-09-29" cert="medium">1621-2</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 209">RLITTS</seg>
+         </head>
          
          <div type="transcription">
             <div>
-               <head>f 154v <date from-iso="1621-11-01" to-iso="1622-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <head>f 154v <date from-iso="1621-11-01" to-iso="1622-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
                <pb n="154v" type="folio"/> 
                <gap reason="omitted"/>   
                <table>

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -444,7 +444,7 @@
          <div type="transcription">
             
             <div>
-               <head>f 36 <date from-iso="1608-11-01" to-iso="16098-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <head>f 36 <date from-iso="1608-11-01" to-iso="1609-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
                <pb n="36" type="folio"/> 
                <gap reason="omitted"/>    
                <table>
@@ -498,7 +498,60 @@
       </body>
    </text>
                
-
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1609-09-29" to-iso="1610-09-29" cert="medium">1609-10</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 144">RLITTS</seg></head>
+         
+         <div type="transcription">
+            
+            <div>
+               <head>f 47v <date from-iso="1609-11-01" to-iso="1610-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <pb n="36" type="folio"/> 
+               <gap reason="omitted"/>    
+               <table>
+                  <row>
+                     <cell>It<ex>em</ex> paid for a play on Alholand day 1609</cell>
+                     <cell>v li.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 48</head>
+               <pb n="48" type="folio"/>
+               <table>
+                  <row>
+                     <cell>Item paid for musicke the same day</cell>
+                     <cell>xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>em</ex> paid for a play on Candlemas day</cell>
+                     <cell>v li.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> paid for musicke the same day</cell>
+                     <cell>xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+         </div>
+      </body>
+   </text>
+               
+               
+               
+               
+               
+               
+               
 
 
 
@@ -581,8 +634,7 @@
                No masque is known to have been performed at Ely House, the bishop of Ely's town residence in Holborn, this year. The 'maske at Elye house' (p 153, l.25) was possibly a rehearsal of Beaumont's masque (see Chambers, <title>Elizabethan Stage</title>, vol 3, 235).   <!-- KC: Cross-reference pagination -->
             </note>
          </div>
-         
-         
+            
          <div>
             <head>f 75v <supplied></supplied></head>
             <pb n="f 75v" type="folio"/>

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -236,6 +236,7 @@
       </revisionDesc>
    </teiHeader>
    
+
    <text ana="taxon:inner_temple" type="record">
       <body xml:lang="eng">
          <head>
@@ -243,7 +244,7 @@
             <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 137-8">RLITTS</seg></head>
          <div type="transcription">
             <div>
-               <head>f 2 <date from-iso="1605-11-01" to-iso="1606-11-01"></date><supplied>( 1 November - 1 November) (All Payments)</supplied></head>
+               <head>f 2 <date from-iso="1605-11-01" to-iso="1606-11-01"></date><supplied>( 1 November - 1 November) (All Payments)</supplied></head> <!-- KC: we don't supply dates in the 1 Nov to 1 Nov line unless it is ambiguious, e.g. 1 Nov 1605 to 2 Nov 1606 -->
                <pb n="2" type="folio"/> 
          
                <gap reason="omitted"/>
@@ -297,7 +298,84 @@
    </text>
    
    
-   
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1606-09-29" to-iso="1607-09-29" cert="medium">1606-7</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 139">RLITTS</seg></head>
+         <div type="transcription">
+            <div>
+               <head>f 12v <date from-iso="1606-11-01" to-iso="1607-11-01"></date><supplied>( 1 November - 1 November) (All Payments)</supplied></head>
+               <pb n="12v" type="folio"/> 
+               
+               <gap reason="omitted"/>   
+               
+               <table>
+                  <row>
+                     <cell>Item paid to the Music<ex>i</ex>ons for their fee on
+                        Alhollandaie 1606</cell>
+                     <cell>xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 13 </head>
+               <pb n="13" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>I
+                        tem paid for 2 staffetorches for the revells on
+                        Candlemas Even</cell>
+                     <cell>ij s.</cell>
+                  </row>
+                  <row>
+                     <cell>Item paid for a play on Candlemas Daye 1606</cell>
+                     <cell>v li.</cell>
+                  </row>
+                  <gap reason="omitted"/>
+                  <row>
+                     <cell>Item paid to the Music<ex>i</ex>ons for their ffee the
+                        same daie</cell>
+                     <cell>xx s.</cell>
+                  </row>
+                  <gap reason="omitted"/>
+                  <row>
+                     <cell>Item paid for 4 staff torches for the Revells the
+                        same daie</cell>
+                     <cell>iiij s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 13v </head>
+               <pb n="13v" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item paid to Raphe Smyth the Carpenter <gap reason="omitted"/> for pullinge
+                        downe the gallery in the hall where the Musicons<note type="foot">Musicons: <hi rend="italic">for</hi> Music<ex>i</ex>ons<hi rend="italic">abbreviation mark missing</hi></note> vse
+                        to staund</cell>
+                     <cell>ij s. vj d.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <note type="editorial" n="endnote">
+                  <ab>While 'the gallery in the hall where the Musicons vse to staund' is mentioned nowhere else, a 'Mussick
+                     Roome' is mentioned in Inner Temple records beginning in 1614–15 (see p 183). These references may
+                     be compared to a place for musicians recorded for Lincoln's Inn records beginning in 1632–3 (see
+                     p 232, ll.15–16). Musical structures of both Inns are discussed in the Introduction, p xxviii–xxxii.
+                  </ab> <!-- KC: cross-reference pagination -->
+               </note>
+            </div>
+         </div>
+      </body>
+   </text>
+
    
    
    

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -365,6 +365,7 @@
                </table>
                <gap reason="omitted"/>
                <note type="editorial" n="endnote">
+                  <!-- KC: @en 139 f 13v -->
                   <ab>While 'the gallery in the hall where the Musicons vse to staund' is mentioned nowhere else, a 'Mussick
                      Roome' is mentioned in Inner Temple records beginning in 1614–15 (see p 183). These references may
                      be compared to a place for musicians recorded for Lincoln's Inn records beginning in 1632–3 (see
@@ -428,6 +429,7 @@
                   <gap reason="omitted"/>
                  
                   <note type="editorial" n="endnote">
+                     <!-- KC: @en 141 IT Arch: FIN/1/1 f 23v -->
                      The 'Oxford Tragedye' is otherwise unknown: see Appendix 6.3.  <!-- KC: Cross-Reference -->
                   </note>
                </div>
@@ -663,6 +665,7 @@
                </table>
                <gap reason="omitted"/>
                <note type="editorial" n="endnote">
+                  <!-- KC: @en 147 IT Arch: FIN/1/1 ff 64-4v -->
                   Antics and puppets, plus the consort, seem to have replaced the customary play on All Saints' Day, due
                   to the ban on the performance of the play.
                </note>
@@ -726,6 +729,7 @@
             </table>
        
          <note type="editorial" n="endnote">
+            <!-- KC: @en 153 IT Arch: FIN/1/1 ff 72v, 73, 75v -->
             <ab>Apparently two different companies were booked for the same afternoon ('another company of players,' p 153, l.14), the second of which did not perform. If so, this is the only instance in the Inner Temple records of a company of players being paid for not performing.</ab>   <!-- KC: Cross-reference pagination -->
          </note>
          </div>
@@ -746,6 +750,7 @@
             </table>
             <gap reason="omitted"/>
             <note type="editorial" n="endnote">
+               <!-- KC: @en 153 IT Arch: FIN/1/1 ff 72v, 73, 75v -->
                No masque is known to have been performed at Ely House, the bishop of Ely's town residence in Holborn, this year. The 'maske at Elye house' (p 153, l.25) was possibly a rehearsal of Beaumont's masque (see Chambers, <title>Elizabethan Stage</title>, vol 3, 235).   <!-- KC: Cross-reference pagination -->
             </note>
          </div>
@@ -773,6 +778,7 @@
                </row>
             </table>
             <note type="editorial" n="endnote">            
+               <!-- KC: @en 153 IT Arch: FIN/1/1 ff 72v, 73, 75v -->
                Winchester House (p 153, l.39) was the residence of the bishop of Winchester in Southwark. It was from Southwark that the Inner Temple and Gray's Inn masquers proceeded by water to Whitehall, the theme of the masque being the marriage of the Rivers Thames and Rhine.  <!-- KC: Cross-reference -->
             </note>
          </div>
@@ -850,6 +856,7 @@
                </table>
                <gap reason="omitted"/>
                <note type="editorial" n="endnote">
+                  <!-- KC: @en 182 IT Arch: FIN/1/1 ff 91v, 92, 94v -->
                   The phrase 'the Kinges Maiesties servantes' (l.18, see also l.28) is the earliest indication of which playing company performed at the Inner Temple. Under one name or another (including the 'Blackfryers
                   Players' in 1629–30: see p 226, l.40) this company – Shakespeare's company – performed at the Inner
                   Temple from this year forward, and perhaps earlier. But in 1601–2 the same company evidently played
@@ -890,6 +897,7 @@
                   </table>
                   <gap reason="omitted"/>
                <note type="editorial" n="endnote">
+                  <!-- KC: @en 182 IT Arch: FIN/1/1 ff 91v, 92, 94v -->
                   The phrase 'the Kinges Maiesties servantes' (l.18, see also l.28) is the earliest indication of which playing company performed at the Inner Temple. Under one name or another (including the 'Blackfryers
                   Players' in 1629–30: see p 226, l.40) this company – Shakespeare's company – performed at the Inner
                   Temple from this year forward, and perhaps earlier. But in 1601–2 the same company evidently played
@@ -910,8 +918,11 @@
                   </table>
                   <gap reason="omitted"/>
                   <note type="editorial" n="endnote">
+                     <!-- KC: @en 182 IT Arch: FIN/1/1 ff 91v, 92, 94v -->
                      It is not clear exactly what was being reimbursed or rewarded by the payment on f 94v. The round
-                     sum would suggest a reward rather than a reimbursement. The spending of domus money suggests                         that the student revellers performed before an invited audience whom the Inn wished to impress.                           (See Bulstrode Whitelocke’s description of organizing the revels at Middle Temple 1628-9, pp 223-6.)
+                     sum would suggest a reward rather than a reimbursement. The spending of domus money suggests 
+                     that the student revellers performed before an invited audience whom the Inn wished to impress. 
+                     (See Bulstrode Whitelocke’s description of organizing the revels at Middle Temple 1628-9, pp 223-6.)
                   </note>  <!-- KC: cross-reference pagination -->
                </div>
          </div>
@@ -982,6 +993,7 @@
                   </row>
                </table>
                <gap reason="omitted"/>
+            </div>
                
                <div>
                   <head>f 106v</head>
@@ -996,7 +1008,7 @@
                      </row>
                   </table>
                   <note type="editorial" n="endnote">
-                     <!-- @en 186-7 -->
+                     <!-- KC: @en 186-7 IT Arch: FIN/1/1 ff 106v, 108 -->
                   </note>  <!-- KC: cross-reference -->
                </div>
                
@@ -1013,11 +1025,12 @@
                   </table>
                   <gap reason="omitted"/>
                   <note type="editorial" n="endnote">
-                     <!-- @en 186-7 -->
+                     <!-- KC: @en 186-7 IT Arch: FIN/1/1 ff 106v, 108 -->
                   </note>  <!-- KC: cross-reference -->
                </div>
-               
-            </div>
+         </div>
+      </body>
+   </text>
                
   
   

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -1197,8 +1197,58 @@
       </body>
    </text>
                
-   
-   
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1618-09-29" to-iso="1619-09-29" cert="medium">1618-9</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 203">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 134v <date from-iso="1618-11-01" to-iso="1619-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <pb n="134v" type="folio"/>   
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m paid to the musicians vppon Alhallond Day</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">13</cell>
+                     <cell rend="right">4</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m paid the v<hi rend="superscripte">th</hi> of November</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">13</cell>
+                     <cell rend="right">4</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m paid to them on Candlemas day</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">13</cell>
+                     <cell rend="right">4</cell>
+                  </row>
+                  <row>
+                     <cell>Item paid to them for their fee one whole yeare</cell>
+                     <cell rend="right">2</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m paid for a play on Candlemas Day</cell>
+                     <cell rend="right">7</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+         </div>
+      </body>
+   </text>
+               
    
    
    

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -557,6 +557,7 @@
                <head>f 55v <date from-iso="1610-11-01" to-iso="1611-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
                <pb n="55v" type="folio"/> 
                <gap reason="omitted"/>      
+               
                <table>
                   <row>
                      <cell>Item paid for a play on Alhallonday Anno
@@ -568,6 +569,7 @@
                      <cell>xx s.</cell>
                   </row>
                </table>
+               
                <gap reason="omitted"/>
                <table>
                   <row>
@@ -579,7 +581,9 @@
                   <cell>ij s.</cell>
                </row>
                </table>
-               <gap reason="omitted"/><table>
+               
+               <gap reason="omitted"/>
+               <table>
                   <row>
                      <cell>Item paid for a play on Candlemas day last</cell>
                      <cell> v li.</cell>
@@ -590,6 +594,7 @@
                   </row>
                </table>
                <gap reason="omitted"/>
+               
                <table>
                   <row>
                      <cell> It<ex>em</ex> paid for 2 staffe torches the same day</cell>

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -1344,6 +1344,56 @@
       </body>
    </text>
    
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1621-09-29" to-iso="1622-09-29" cert="medium">1621-22</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 209">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 154v <date from-iso="1621-11-01" to-iso="1622-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <pb n="154v" type="folio"/> 
+               <gap reason="omitted"/>   
+               <table>
+                  <row>
+                     <cell>It<ex>em</ex> paid to the Kinges players for two plaies on
+                        Allhallonday &amp; Candlemas day last</cell>
+                     <cell rend="right">14</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 155</head>
+               <pb n="155" type="folio"/>
+               <table>
+                  <row>
+                     <cell></cell>
+                     <cell rend="right">li.</cell>
+                     <cell rend="right">s.</cell>
+                     <cell rend="right">d.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> to the Musitians for their ffee for this yeere &amp; the
+                        5<hi rend="superscript">th</hi> of Novemb<ex>er</ex></cell>
+                     <cell rend="right">2</cell>
+                     <cell rend="right">13</cell>
+                     <cell rend="right">4</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>               
+            </div>
+         </div>
+      </body>
+   </text>
+   
+   
+   
+   
    
    
    

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -1425,8 +1425,48 @@
       </body>
    </text>
    
-   
-   
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1622-09-29" to-iso="1623-09-29" cert="medium">1622-3</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 210">RLITTS</seg>
+         </head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 160v <date from-iso="1622-11-01" to-iso="1623-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied>
+               </head>
+               <pb n="160v" type="folio"/> 
+               <gap reason="omitted"/>   
+               <table>
+                  <row>
+                     <cell>Item p<ex>ai</ex>d for a play all S<ex>ain</ex>t<ex>es</ex> day</cell>
+                     <cell rend="right">7</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item to the Music<ex>i</ex>ons for their wages this yeare</cell>
+                     <cell rend="right">2</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m to them more for playeng the fifte of November</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">13</cell>
+                     <cell rend="right">4</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+         </div>
+      </body>
+   </text>
+               
    
    
    

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -607,7 +607,72 @@
          </div>
       </body>
    </text>
- 
+   
+   
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1611-09-29" to-iso="1612-09-29" cert="medium">1611-12</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 147">RLITTS</seg></head>
+         
+         <div type="transcription">
+            
+            <div>
+               <head>f 64-4v <date from-iso="1611-11-01" to-iso="1612-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <pb n="64-4v" type="folio"/> 
+               <gap reason="omitted"/>       
+               <table>
+                  <row>
+                     <cell>Item paid for 2 staffe torches vppon Alhollowday</cell>
+                     <cell>ij s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>em</ex> paid to the Musicions for their ffee the same day</cell>
+                     <cell>xx s.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> paid for a Consort of Musicke the same day</cell>
+                     <cell>l s.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> for Antick<ex>es</ex> or puppitt<ex>es</ex> the same day</cell>
+                     <cell>xl s.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> paid for the Music<ex>i</ex>ons ffee the 5 of N<ex>ovember</ex></cell>
+                     <cell>xiij s. iiij d.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item paid for 2 staffe torches on Candlemas day</cell>
+                     <cell>ij s. |</cell>
+                  </row>
+                  <row>
+                     <cell>Item paid for a play the same day</cell>
+                     <cell>vj li.</cell>
+                  </row>
+                  <row>
+                     <cell>Item paid for Musicke the same day</cell>
+                     <cell>xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <note type="editorial" n="endnote">
+                  Antics and puppets, plus the consort, seem to have replaced the customary play on All Saints' Day, due
+                  to the ban on the performance of the play.
+               </note>
+            </div>
+            
+         </div>
+      </body>
+   </text>
+               
+               
                
                
                

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -493,7 +493,6 @@
                </table>
                <gap reason="omitted"/>
             </div>
-               
             </div>    
       </body>
    </text>
@@ -546,7 +545,64 @@
       </body>
    </text>
                
-               
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1610-09-29" to-iso="1611-09-29" cert="medium">1610-11</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 146">RLITTS</seg></head>
+         
+         <div type="transcription">
+            
+            <div>
+               <head>f 55v <date from-iso="1610-11-01" to-iso="1611-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <pb n="55v" type="folio"/> 
+               <gap reason="omitted"/>      
+               <table>
+                  <row>
+                     <cell>Item paid for a play on Alhallonday Anno
+               D<ex>omi</ex>ni 1610</cell> 
+                     <cell>vj li.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> paid for Musick the same day</cell> 
+                     <cell>xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Item paid for Musicke the 5 No<ex>vember</ex> 1610</cell> 
+                     <cell>xiij s. iiij d.</cell>
+                  </row>
+               <row>
+                  <cell>Item paid for two staffe torches the same day</cell> 
+                  <cell>ij s.</cell>
+               </row>
+               </table>
+               <gap reason="omitted"/><table>
+                  <row>
+                     <cell>Item paid for a play on Candlemas day last</cell>
+                     <cell> v li.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> paid for musicke the same day</cell>
+                     <cell> xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell> It<ex>em</ex> paid for 2 staffe torches the same day</cell>
+                     <cell>ij s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+         </div>
+      </body>
+   </text>
+ 
                
                
                

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -433,11 +433,76 @@
                </div>
          </div>
       </body>
+   </text>              
+               
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1608-09-29" to-iso="1609-09-29" cert="medium">1608-9</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 142">RLITTS</seg></head>
+         
+         <div type="transcription">
+            
+            <div>
+               <head>f 36 <date from-iso="1608-11-01" to-iso="16098-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <pb n="36" type="folio"/> 
+               <gap reason="omitted"/>    
+               <table>
+                  <row>
+                     <cell>Ite<ex>m</ex> paid for a play on Allhollen Daie anno
+                        d<ex>omi</ex>ni 1608</cell>
+                     <cell>iiij li. xv s.</cell>
+                  </row>
+               </table>
+            </div>
+            
+            <div>
+               <head>f 36v</head>
+               <pb n="36v" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>Ite<ex>m</ex> paid to the music<ex>i</ex>ons the same daie</cell>
+                     <cell>xx s.</cell>
+                  </row>
+                  <row>
+                     <cell>Ite<ex>m</ex> paid for 3 do<ex>ssen</ex> 3 torches spent this whole
+                        yeare at Revells at x s. the dozen</cell>
+                     <cell>xxxij s. vj d.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 37v</head>
+               <pb n="37v" type="folio"/>
+               <gap reason="omitted"/>
+               
+               <table>
+                  <row>
+                     <cell>Ite<ex>m</ex> given to the gent<ex>lemens</ex> Revelles in Mich<ex>aelm</ex>as
+                        Terme 3 revelling night<ex>es</ex></cell>
+                     <cell>iij li.</cell>
+                  </row>
+                     <gap reason="omitted"/>
+                  <row>
+                     <cell>Ite<ex>m</ex> paied for a play on Candlemas Daie laste 1608</cell>
+                     <cell>v li.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+               
+            </div>    
+      </body>
    </text>
                
-   
-   
-   
+
+
+
+
+
 <!-- =============================================== -->   
 <!-- KC: record added by Diane Jakacki -->
    <text ana="taxon:inner_temple" type="record">

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -1295,7 +1295,54 @@
       </body>
    </text>
    
-   
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1620-09-29" to-iso="1621-09-29" cert="medium">1620-21</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 206-7">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 146v <date from-iso="1620-11-01" to-iso="1621-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <pb n="146v" type="folio"/> 
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d for twoe plaies one all S<ex>ain</ex>t<ex>es</ex> &amp; candlemas day</cell>
+                     <cell rend="right">14</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to ye Musitions then<note type="foot">then: <hi rend="italic">All Saints' Day</hi></note></cell>
+                     <cell rend="right">1</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to the Musitions for the fift day of No<ex>vem</ex>ber</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">13</cell>
+                     <cell rend="right">4</cell>
+                  </row>                  
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to ye Musitions then</cell>
+                     <cell rend="right">1</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+         </div>
+      </body>
+   </text>
    
    
    

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -1032,10 +1032,129 @@
       </body>
    </text>
                
-  
-  
-  
-  
-  
-  
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1616-09-29" to-iso="1617-09-29" cert="medium">1616-17</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 191-2">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 114 <date from-iso="1616-11-01" to-iso="1617-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <pb n="114" type="folio"/>
+               <gap reason="omitted"/>  
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to the king<ex>es</ex> Maie<ex>s</ex>ti<ex>es</ex> servant<ex>es</ex> for a
+                        playe vpon Allhallon<del>tyde</del> day 1616</cell>
+                     <cell rend="right">vj li. xiij s. iiij d.</cell>
+                  </row>
+               </table>
+            </div>
+            
+            <div>
+               <head>f 114v</head>
+               <pb n="114v " type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m paid for 2 staffe torches the same daye</cell>
+                     <cell rend="right">ij s.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m paied to Iohn Hopper for the Musitions
+                        ffee the same day</cell>
+                     <cell rend="right">xx s.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m paied ffor the Musitions ffee the ffift
+                        of November</cell>
+                     <cell rend="right"></cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 115v</head>
+               <pb n="115v" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to ffrancis Lownds for the hyer of nap<ex>er</ex>ie
+                        and plate on Candlemas day</cell>
+                     <cell rend="right">xxvj s. viij d.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to Iohn Hopper for the Musitions ffee
+                        the same daye</cell>
+                     <cell rend="right">xx s.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d for 2 staffe torches the same daye</cell>
+                     <cell rend="right">ij s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to Mr Brownlowe of the Bench for money
+                        borrowed toward<ex>es</ex> the Charge of Barryers</cell>
+                     <cell rend="right">l li.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+            
+            <div>
+               <head>f 119</head>
+               <pb n="119" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to S<ex>i</ex>r Thomas Coventry for money lent
+                        toward<ex>es</ex> the barryers being parte of debt of l li.</cell>
+                     <cell rend="right">xx li.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+               
+            <div>
+               <head>f 119v</head>
+               <pb n="119v" type="folio"/>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to Sir Thomas Coventry</cell>
+                     <cell rend="right">xxx li.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to Mr Martyne of the Middle temple and to
+                        one Gilles a Taylor by the appoyntm<ex>en</ex>t of Mr Iorden</cell>
+                     <cell rend="right">xl li.</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>e</ex>m p<ex>ai</ex>d to Richard Mayer for Collectinge of the
+                        barryers money</cell>
+                     <cell rend="right">l s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+         </div>
+      </body>
+   </text>
+   
+   
+   
+   
+   
+   
+   
+   
+   
+   
+   
+   
 </TEI>

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -1146,8 +1146,57 @@
       </body>
    </text>
    
-   
-   
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1617-09-29" to-iso="1618-09-29" cert="medium">1617-18</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 201-2">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 126v <date from-iso="1617-11-01" to-iso="1618-11-01"></date><supplied>(1 November - 1 November) (Payments)</supplied></head>
+               <pb n="126v" type="folio"/>   
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell></cell>
+                     <cell rend="right">li.</cell>
+                     <cell rend="right">s.</cell>
+                     <cell rend="right">d.</cell>
+                  </row><row>
+                     <cell>Imprimis paid for a play on Alhollon day</cell>
+                     <cell rend="right">6</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> paid paid<note type="foot">paid paid: <hi rend="italic">dittography</hi></note> for a playe on Candlemas daye</cell>
+                     <cell rend="right">6</cell>
+                     <cell rend="right">013</cell>
+                     <cell rend="right">4</cell>
+                  </row>
+                  <row>
+                     <cell>It<ex>em</ex> paid to the Musitions for the fifte of november</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">13</cell>
+                     <cell rend="right">4</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+               <table>
+                  <row>
+                     <cell>It<ex>em</ex> paid to the Musitions for a yere ffee</cell>
+                     <cell rend="right">2</cell>
+                     <cell rend="right">0</cell>
+                     <cell rend="right">0</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+         </div>
+      </body>
+   </text>
+               
    
    
    

--- a/IT_TreaStewButlAccounts.xml
+++ b/IT_TreaStewButlAccounts.xml
@@ -244,7 +244,7 @@
             <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 137-8">RLITTS</seg></head>
          <div type="transcription">
             <div>
-               <head>f 2 <date from-iso="1605-11-01" to-iso="1606-11-01"></date><supplied>( 1 November - 1 November) (All Payments)</supplied></head> <!-- KC: we don't supply dates in the 1 Nov to 1 Nov line unless it is ambiguious, e.g. 1 Nov 1605 to 2 Nov 1606 -->
+               <head>f 2 <date from-iso="1605-11-01" to-iso="1606-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head> <!-- KC: we don't supply year dates in the 1 Nov to 1 Nov line unless it is ambiguious, e.g. 1 Nov 1605 to 2 Nov 1606 -->
                <pb n="2" type="folio"/> 
          
                <gap reason="omitted"/>
@@ -305,7 +305,7 @@
             <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 139">RLITTS</seg></head>
          <div type="transcription">
             <div>
-               <head>f 12v <date from-iso="1606-11-01" to-iso="1607-11-01"></date><supplied>( 1 November - 1 November) (All Payments)</supplied></head>
+               <head>f 12v <date from-iso="1606-11-01" to-iso="1607-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
                <pb n="12v" type="folio"/> 
                
                <gap reason="omitted"/>   
@@ -376,7 +376,65 @@
       </body>
    </text>
 
-   
+
+   <text ana="taxon:inner_temple" type="record">
+      <body xml:lang="eng">
+         <head>
+            <date from-iso="1607-09-29" to-iso="1608-09-29" cert="medium">1607-8</date>
+            <seg ana="taxon:RLITTS" corresp="taxon:RPCIC p. 141">RLITTS</seg></head>
+         
+         <div type="transcription">
+            <div>
+               <head>f 23 <date from-iso="1607-11-01" to-iso="1608-11-01"></date><supplied>( 1 November - 1 November) (All payments)</supplied></head>
+               <pb n="23" type="folio"/> 
+               <gap reason="omitted"/>   
+               <table>
+                  <row>
+                     <cell>Item paid for the Musitions fee the same day<note type="foot">the same day: <hi rend="italic">All Hallows' Day</hi></note></cell>
+                     <cell>xx s.</cell>
+                  </row>
+               </table>
+               <gap reason="omitted"/>
+            </div>
+               
+               <div>
+                  <head>f 23v </head>
+                  <pb n="23v" type="folio"/>
+                  <gap reason="omitted"/>
+                  <table>
+                     <row>
+                        <cell>Item paid for 2 staffe torches for the revells on
+                           Candlemas Even</cell>
+                        <cell>ij s.</cell>
+                     </row>
+                      <row>
+                         <cell>Item paid for a play on Candlemas Day called
+                            Oxford Tragedye</cell>
+                         <cell>v li.</cell>
+                      </row>
+                  </table>
+                   <gap reason="omitted"/>
+                  <table>
+                     <row>
+                        <cell>Item paid for 2 staffe torches the same daye</cell>
+                        <cell>ij s.</cell>
+                     </row>
+                     <row>
+                        <cell>Item paid to the Music<ex>i</ex>ons for their ffee the
+                           same Daye</cell>
+                        <cell>xx s.</cell>
+                     </row>
+                  </table>
+                  <gap reason="omitted"/>
+                 
+                  <note type="editorial" n="endnote">
+                     The 'Oxford Tragedye' is otherwise unknown: see Appendix 6.3.  <!-- KC: Cross-Reference -->
+                  </note>
+               </div>
+         </div>
+      </body>
+   </text>
+               
    
    
    
@@ -388,6 +446,7 @@
             <date from-iso="1612" to-iso="1613">1612-1613</date>
             <seg ana="taxon:RLITTS" corresp="taxon:RLPIC1 pp. 153, 176">RLITTS</seg></head>
          <div type="transcription">
+            <div>
             <head>f 72v <supplied>(1 November - 1 November) (Payments)</supplied></head>
             <pb n="f 72v" type="folio"/>
             <gap reason="omitted"/>
@@ -432,12 +491,13 @@
                   <cell>x s.</cell>
                </row>               
             </table>
-         </div>
-         <div type="endnote">
-            <ab>Apparently two different companies were booked for the same afternoon (‘another company of players,’ p 153, l.14), the second of which did not perform. If so, this is the only instance in the Inner Temple records of a company of players being paid for not performing.</ab>
+       
+         <note type="editorial" n="endnote">
+            <ab>Apparently two different companies were booked for the same afternoon ('another company of players,' p 153, l.14), the second of which did not perform. If so, this is the only instance in the Inner Temple records of a company of players being paid for not performing.</ab>   <!-- KC: Cross-reference pagination -->
+         </note>
          </div>
             
-         <div type="transcription">
+         <div>
             <head>f 73 <supplied></supplied></head>
             <pb n="f 73" type="folio"/>
             <gap reason="omitted"/>
@@ -452,12 +512,13 @@
                </row>
             </table>
             <gap reason="omitted"/>
-         </div>
-         <div type="endnote">
-            <ab>No masque is known to have been performed at Ely House, the bishop of Ely’s town residence in Holborn, this year. The ‘maske at Elye house’ (p 153, l.25) was possibly a rehearsal of Beaumont’s masque (see Chambers, <hi rend="italic">Elizabethan Stage</hi>, vol 3, 235).</ab>
+            <note type="editorial" n="endnote">
+               No masque is known to have been performed at Ely House, the bishop of Ely's town residence in Holborn, this year. The 'maske at Elye house' (p 153, l.25) was possibly a rehearsal of Beaumont's masque (see Chambers, <title>Elizabethan Stage</title>, vol 3, 235).   <!-- KC: Cross-reference pagination -->
+            </note>
          </div>
          
-         <div type="transcription">
+         
+         <div>
             <head>f 75v <supplied></supplied></head>
             <pb n="f 75v" type="folio"/>
             <gap reason="omitted"/>
@@ -471,7 +532,7 @@
                   <cell>x li.</cell>
                </row>
                <row>
-                  <cell>Item paid to a messinger w<ex>hi</ex>ch Mr ffenner p<ex>ro</ex>vided ^<add place="above">to fetch Mr Beamont</add></cell>
+                  <cell>Item paid to a messinger w<ex>hi</ex>ch Mr ffenner p<ex>ro</ex>vided ‸<add place="above">to fetch Mr Beamont</add></cell>
                </row>
                <gap reason="omitted"/>
                <row>
@@ -479,13 +540,12 @@
                   <cell>ij s. vj d.</cell>
                </row>
             </table>
+            <note type="editorial" n="endnote">            
+               Winchester House (p 153, l.39) was the residence of the bishop of Winchester in Southwark. It was from Southwark that the Inner Temple and Gray's Inn masquers proceeded by water to Whitehall, the theme of the masque being the marriage of the Rivers Thames and Rhine.
+            </note>
          </div>
          
-         <div type="endnote">            
-            <ab>Winchester House (p 153, l.39) was the residence of the bishop of Winchester in Southwark. It was from Southwark that the Inner Temple and Gray’s Inn masquers proceeded by water to Whitehall, the theme of the masque being the marriage of the Rivers Thames and Rhine.</ab>
-         </div>
-         
-         <div type="transcription">
+         <div>
             <head>f 82 <supplied>(1 November - 1 November) (Payments)</supplied></head>
             <pb n="f 82" type="folio"/>
             <gap reason="omitted"/>
@@ -524,9 +584,7 @@
                <gap reason="omitted"/>
             </table>
          </div>
-                   
-
-
+         </div>
       </body>
    </text>
   

--- a/KC-ITendnotes.xml
+++ b/KC-ITendnotes.xml
@@ -235,19 +235,108 @@
       </revisionDesc>
    </teiHeader>
    
+ <text>
+    <body>
+       <div type="endnote">
+             <p>@en 139 IT Arch: FIN/1/1 f 13v</p>
+          <p>While 'the gallery in the hall where the Musicons vse to staund' is mentioned nowhere else, a 'Mussick
+          Roome' is mentioned in Inner Temple records beginning in 1614-15 (see p 183). These references may
+          be compared to a place for musicians recorded for Lincoln's Inn records beginning in 1632-3 (see
+          p 232, ll.15-16). Musical structures of both Inns are discussed in the Introduction, p xxviii-xxxii.</p>
+          <!-- KC: Cross-ref -->
+       </div>
+    </body>
+ </text>  
+   
+   <text>
+      <body>
+         <div type="endnote">
+               <p>@en 141 IT Arch: FIN/1/1 f 23v</p>
+               <p>The 'Oxford Tragedye' is otherwise unknown: see Appendix 6.3.</p>
+         </div>
+      </body>
+   </text>
+   
+   <text>
+      <body>
+         <div type="endnote">
+               <p>@en 147 IT Arch: FIN/1/1 ff 64-4v</p>
+               <p>Antics and puppets, plus the consort, seem to have replaced the customary play on All Saints' Day, due
+               to the ban on the performance of the play.</p>
+         </div>
+      </body>
+   </text>
+   
+   <text>
+      <body>
+         <div type="endnote">
+            <p>@en 151-2 IT Arch: PAR/1/2 f 112v</p>
+            <p>The phrase 'late showe and sportes' (p 151, l.41) refers to Beaumont’s <title>Masque of the Inner Temple and
+               Gray’s Inn</title>, performed in the Banqueting House, Whitehall, on 20 February 1612/13, following the
+               marriage of Princess Elizabeth and the count palatine. The figure 'xijC li.'(£1200), if doubled to allow
+               for Gray’s Inn's share, tallies roughly with the total of £2255 8s 11d calculated by Orbison (ed), <title>Collections</title>
+               12, p 7, to have been the cost of George Chapman’s masque presented by the Middle Temple and
+               Lincoln's Inn for the same occasion.</p>
+         </div>
+      </body>
+   </text>
+   
+   
+   <text>
+      <body>
+         <div type="endnote">
+            <p>@en 153 IT Arch: FIN/1/1 ff 72v, 73, 75v</p> 
+               <p>Apparently two different companies were booked for the same afternoon ('another company of players,'
+               p 153, l.14), the second of which did not perform. If so, this is the only instance in the Inner Temple
+               records of a company of players being paid for not performing.</p>
+               <p>No masque is known to have been performed at Ely House, the bishop of Ely's town residence in
+               Holborn, this year. The 'maske at Elye house' (p 153, l.25) was possibly a rehearsal of Beaumont's
+               masque (see Chambers, <title>Elizabethan Stage</title>, vol 3, 235).</p>
+               <p>Winchester House (p 153, l.39) was the residence of the bishop of Winchester in Southwark. It was
+               from Southwark that the Inner Temple and Gray's Inn masquers proceeded by water to Whitehall, the
+               theme of the masque being the marriage of the Rivers Thames and Rhine.</p>
+            <!-- KC: Cross-ref -->
+         </div>
+      </body>
+   </text>
+   
+   <text>
+      <body>
+         <div type="endnote">
+            <p>@en 182 IT Arch: FIN/1/1 ff 91v, 92, 94v</p>           <!-- KC: Cross-ref -->
+               <p>The phrase 'the Kinges Maiesties servantes' (l.18, see also l.28) is the earliest indication of which playing company performed at the Inner Temple. Under one name or another (including the 'Blackfryers
+               Players' in 1629-30: see p 226, l.40) this company - Shakespeare's company - performed at the Inner
+               Temple from this year forward, and perhaps earlier. But in 1601-2 the same company evidently played
+               at the Middle Temple: see Appendix 6.3, <title>Twelfth Night</title>.</p>
+               <p>It is not clear exactly what was being reimbursed or rewarded by the payment on f 94v. The round
+               sum would suggest a reward rather than a reimbursement. The spending of domus money suggests
+               that the student revellers performed before an invited audience whom the Inn wished to impress. (See
+               Bulstrode Whitelocke's description of organizing the revels at Middle Temple 1628-9, pp 223-6.)</p>
+         </div>
+      </body>
+   </text>
+   
+   
 <text>
    <body>
       <div type="endnote">
-         <ab>@en 186-7 IT Arch: FIN/1/1 ff 106v, 108
-         The 'maske to court' (p 186, ll.38-9), that is, the masque that was taken to court, was Beaumont's
+          <p>@en 186-7 IT Arch: FIN/1/1 ff 106v, 108</p>
+         <p>The 'maske to court' (p 186, ll.38-9), that is, the masque that was taken to court, was Beaumont's
          <title>Masque of the Inner Temple and Gray's Inn</title>, performed in the Banqueting House, Whitehall, on 20
          February 1612/13. The 'barryers' (p 187, l.4) may be an anticipatory (or misdated) reference to the
-         barriers entertainment held on 4 November 1616 (see Appendix 6.1).</ab> <!-- Cross-ref -->
+         barriers entertainment held on 4 November 1616 (see Appendix 6.1).</p>
+         <!-- KC: Cross-ref -->
       </div>
    </body>
 </text>
    
-  
+   <text>
+      <body>
+         <div type="endnote">
+            <p></p>
+         </div>
+      </body>
+   </text>
   
   
   

--- a/KC-ITendnotes.xml
+++ b/KC-ITendnotes.xml
@@ -316,7 +316,6 @@
       </body>
    </text>
    
-   
 <text>
    <body>
       <div type="endnote">

--- a/KC-ITendnotes.xml
+++ b/KC-ITendnotes.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="REED.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="REED.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:base="tei/records/" xml:id="london" xml:lang="eng"> 
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            
+            <title type="main">Inns of Court</title>
+
+            
+            <funder><orgName>Andrew W. Mellon Foundation, New York, United States of America</orgName></funder>
+            <funder><orgName>CANARIE</orgName></funder> 
+            
+            <funder><orgName>British Academy, London, UK</orgName></funder>
+            <funder><orgName>Jackman Foundation, Toronto, Canada</orgName></funder>            
+            <funder><orgName>National Endowment for the Humanities, Washington, DC, United States of
+               America</orgName></funder>
+            <funder><orgName>Social Sciences and Humanities Research Council, Ottawa,
+               Canada</orgName></funder>
+            
+		 <editor resp="print"><persName xml:id="AHN1">Alan H. Nelson</persName></editor>
+		 <editor resp="print"><persName>John R. Elliott, Jr.</persName></editor>
+            
+            <respStmt>
+               <persName xml:id="CB">Carolyn Black</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>Project Manager</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>John Bradley</persName>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Susan Brown</persName> 
+               <orgName>University of Guelph</orgName>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName xml:id="KC">Kathy Chung</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>REED Research Associate, NHPRC-Mellon Project Consultant</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>William Cooke</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>English Glossarian</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName xml:id="JC">James Cummings</persName>
+               <orgName>Newcastle University</orgName>
+               <resp>Records of Early English Drama (REED) Executive Board</resp>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+               <resp>TEI Schema Designer, Technical Consultant</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Matthew Davies</persName>
+               <orgName>University of London, Birkbeck College</orgName> <!-- confirm -->
+               <resp>Records of Early English Drama (REED) Executive Board</resp>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName xml:id="PG">Patrick Gregory</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>Associate Editor</resp> <!-- confirm -->
+               <resp>Paleographer, Translator</resp> <!-- confirm -->
+            </respStmt>
+            <respStmt>
+               <persName>Tanya Hagen</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>Bibliographer, NHPRC-Mellon Project Consultant</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName xml:id="JAKA1">Diane K. Jakacki</persName>
+               <orgName>Bucknell University</orgName>
+               <resp>Records of Early English Drama (REED) Executive Board</resp>
+               <resp>Principal Investigator, NHPRC-Mellon Digital Edition Publishing Cooperatives Planning Grant</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Alexandra F. Johnston</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>REED Founder and Senior Consultant</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>David Kathman</persName>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Sally-Beth MacLean</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>Principal Investigator, SSHRC grant; Director of Research and General Editor</resp>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+            </respStmt>
+
+            <respStmt>
+               <persName>Maureen Maclean</persName>
+               <orgName>Bucknell University</orgName>
+               <resp>REED London research assistant, 2018</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName xml:id="KM">Kimberley Martin</persName>
+               <orgName>University of Guelph</orgName>
+               <resp>NHPRC-Mellon Project Consultant</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Christopher Matusiak</persName>
+               <orgName>Ithaca College</orgName>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName xml:id="JN">Jamie Norrish</persName>
+               <resp>Programmer, EATS developer, NHPRC-Mellon Project Consultant</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Dorothy Porter</persName>
+               <orgName>University of Pennsylvania</orgName>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Arleane Ralph</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>Paleographer</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Suzanne Westfall</persName>
+               <orgName>Lafayette College</orgName>
+               <resp>Records of Early English Drama (REED) Executive Board Member</resp>
+               <resp>NHPRC-Mellon Project Team Member</resp>
+            </respStmt>
+            
+            <respStmt>
+               <persName>Abigail Ann Young</persName>
+               <orgName>Records of Early English Drama (REED)</orgName>
+               <resp>Latin Glossarian</resp>
+            </respStmt>
+            
+         </titleStmt>
+         <editionStmt>
+            <edition>Print version, published <date when-iso="2010">2010</date>. Electronic edition, anticipated publication <date when-iso="2018">2018</date></edition>
+         </editionStmt>
+         
+         <publicationStmt>
+            <authority><orgName>Records of Early English Drama (REED)</orgName>
+               <address>
+                  <addrLine>University of Toronto</addrLine>
+                  <addrLine>170 St George Street, Suite 810</addrLine>
+                  <addrLine>Toronto, Ontario, Canada</addrLine>
+                  <addrLine>M5R 2M8</addrLine>
+               </address>
+            </authority>
+            
+            <publisher>D.S. Brewer, Cambridge, an imprint of Boydell &amp; Brewer Ltd./Boydell &amp; Brewer Ltd.</publisher>
+            <pubPlace>Rochester, NY</pubPlace>
+            <date>2010</date>
+            <idno type="other">978-1-84384-259-0</idno>
+            
+            <availability>
+               <p>Copyright <orgName>Records of Early English Drama (REED)</orgName>,
+                  <date>2017</date></p>
+               <licence target="https://creativecommons.org/licenses/by-nc-sa/4.0/">Distributed under a
+                  Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA
+                  4.0) licence.</licence>
+            </availability>
+         </publicationStmt>
+         
+         <seriesStmt>
+            <title>Records of Early English Drama</title>
+         </seriesStmt>
+         <sourceDesc>
+            <p>This publication constitutes a remediation of the printed Inns of Court collection. Information on original sources for transcriptions can be accessed via the Document Descriptions.</p>
+            <p>For a full list of REED collections, editors, executive board members, and staff, please visit http://reed.utoronto.ca/people</p>       
+         </sourceDesc>
+      </fileDesc>
+      
+      <encodingDesc>
+         <listPrefixDef>
+            <prefixDef ident="taxon" matchPattern="([A-Za-z0-9_-]+)"
+               replacementPattern="../taxonomy.xml#$1">
+               <p>Private URIs using the <code>taxon</code> prefix are pointers to entities in the
+                  taxonomy.xml file. For example, <code>taxon:church</code> dereferences to
+                  <code>taxonomy.xml#church</code>.</p>
+            </prefixDef>
+            <prefixDef ident="gloss" matchPattern="([A-Za-z0-9_-]+)"
+               replacementPattern="../glossary.xml#$1">
+               <p>Private URIs using the <code>gloss</code> prefix are pointers to entities in the
+                  glossary.xml file. For example, <code>gloss:histrio-1</code> dereferences to
+                  <code>glossary.xml#histrio-1</code>.</p>
+            </prefixDef>
+         </listPrefixDef>
+         
+         <projectDesc>
+            <p>Records of Early English Drama (REED) is an international scholarly project that is
+               establishing for the first time the context from which the drama of Shakespeare and his
+               contemporaries grew. Founded in 1976, REED has worked since then to locate, transcribe,
+               and edit historical documents containing evidence of drama, secular music, and other
+               communal entertainment and ceremony from the Middle Ages until 1642, when the Puritans
+               closed the London theatres.</p>
+         </projectDesc>
+      </encodingDesc>
+      
+      <profileDesc>
+         <langUsage>
+            <language ident="eng">English</language>
+            <language ident="lat">Latin</language>
+            <language ident="fra">Anglo-French</language>
+         </langUsage>
+         <settingDesc>
+            <place>
+               <placeName>London</placeName> 
+            </place>
+         </settingDesc>
+      </profileDesc>
+      <revisionDesc>
+         <!-- Add new major milestone changes to top -->
+         <change when="2018-05-16" who="#KC">created file</change>
+      </revisionDesc>
+   </teiHeader>
+   
+<text>
+   <body>
+      <div type="endnote">
+         <ab>@en 186-7 IT Arch: FIN/1/1 ff 106v, 108
+         The 'maske to court' (p 186, ll.38-9), that is, the masque that was taken to court, was Beaumont's
+         <title>Masque of the Inner Temple and Gray's Inn</title>, performed in the Banqueting House, Whitehall, on 20
+         February 1612/13. The 'barryers' (p 187, l.4) may be an anticipatory (or misdated) reference to the
+         barriers entertainment held on 4 November 1616 (see Appendix 6.1).</ab> <!-- Cross-ref -->
+      </div>
+   </body>
+</text>
+   
+  
+  
+  
+  
+  
+  
+</TEI>


### PR DESCRIPTION
Hi Diane,

This is interim additions to the ITTSB file. As with the parliament book, I'm keeping records in one file until I'm ready to batch upload to CWRC.

Note use of <cell rend="right></cell> to tag account figures which are right aligned. See also 1617-18 record (vol. 1, p 201) for proposed format for this type of table (4 cells per row, last 3 cells right aligned).

For the TSB file, I'm trying out the suggestion of putting endnotes in a separate file and having "pointers" to that file.  So... I've also added a temporary/dummy endnotes file: "KC-ITendnotes.xml". (See file.) For now, I'm using an "@en" string to start an endnote section and the page and folio references to identify specific endnotes (which mirrors vol. 3 format for now). I've put endnotes in the file in `<div type="endnote"></div>` elements and `<p></p>` elements for now. Can do a batch find and replace when people decided what to do with the file content. 

comments welcomed here or on slack. -- K.

